### PR TITLE
Non iterable items threw errors in v0.45

### DIFF
--- a/mat73/__init__.py
+++ b/mat73/__init__.py
@@ -76,7 +76,13 @@ class HDF5Decoder():
                 if matlab_class==b'struct' and len(elem)>1:
                     # convert struct to its proper form as in MATLAB
                     # i.e. struct[0]['key'] will access the elements
-                    items = zip(*[v for v in unpacked.values()])
+                    items = []
+                    for item in unpacked.values():
+                        try:
+                            iter(item)
+                            items.append(item)
+                        except TypeError:
+                            items.append([item])
                     keys = unpacked.keys()
                     struct = [{k:v for v,k in zip(row, keys)} for row in items]
                     struct = [self._dict_class(d) for d in struct]


### PR DESCRIPTION
Non-iterable fields in .mat files (e.g. integers) would throw a `TypeError` unless you wrap them in an iterable container.
I've switched the list comprehension for a for loop which checks if items can be iterated and if not, wraps them in a list.

`zip([1, 2, 3], 1])` throws a `Type Error`.

In my addition, this becomes `zip([1, 2, 3], [1])` which is zip-safe.

Thanks for this amazing package, it's so useful!