### PR TITLE
speed up _is_ref check

### DIFF
--- a/mat73/__init__.py
+++ b/mat73/__init__.py
@@ -65,7 +65,6 @@ class HDF5Decoder():
                 raise ValueError('can only unpack .mat')
         return d
     
-   
     def unpack_mat(self, hdf5, depth=0):
         """
         unpack a h5py entry: if it's a group expand,
@@ -115,14 +114,12 @@ class HDF5Decoder():
         else:
             raise Exception(f'Unknown hdf5 type: {key}:{type(hdf5)}')
 
-
+    # @profile
     def _has_refs(self, dataset):
-        if len(dataset)==0: return False
-        if not isinstance(dataset[0], np.ndarray): return False
+        if len(dataset.shape)<2: return False
         if isinstance(dataset[0][0], h5py.h5r.Reference):  
             return True
         return False
-
 
     def convert_mat(self, dataset, depth):
         """
@@ -244,5 +241,5 @@ if __name__=='__main__':
     # d = loadmat('../tests/testfile5.mat', use_attrdict=True)
 
 
-    file = '../tests/testfile7.mat'
+    file = '../tests/testfile8.mat'
     data = loadmat(file)

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ with open("README.md", "r") as fh:
     
 setuptools.setup(
      name='mat73',  
-     version='0.52',
+     version='0.53',
      author="skjerns",
      author_email="nomail@nomail.com",
      description="Load MATLAB .mat 7.3 into Python native data types",
      long_description=long_description,
    long_description_content_type="text/markdown",
      url="https://github.com/skjerns/mat7.3",
-     download_url="https://github.com/skjerns/mat7.3/archive/v0.52.tar.gz",
+     download_url="https://github.com/skjerns/mat7.3/archive/v0.53.tar.gz",
      install_requires=['h5py', 'numpy'],
      license='MIT',
      packages=['mat73'],

--- a/tests/test_mat73.py
+++ b/tests/test_mat73.py
@@ -31,7 +31,7 @@ print(f'#### Installed version: mat73-{version} on {branch}({name}) "{message}" 
 class Testing(unittest.TestCase):
 
     def setUp(self):
-        for i in range(1,8):
+        for i in range(1,9):
             file = 'testfile{}.mat'.format(i)
             if not os.path.exists(file):
                 file = os.path.join('./tests', file)
@@ -337,7 +337,11 @@ class Testing(unittest.TestCase):
     def test_file7_empty_cell_array(self):
         data = mat73.loadmat(self.testfile7)
         
-    
+    def test_file8_large(self):
+        import stimer
+        with stimer:
+            data = mat73.loadmat(self.testfile8)
+            
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Improve speed by changing the way we check if something is a h5py reference or not

related: #23 