### PR TITLE
add strict suffix mode option

### DIFF
--- a/mat73/__init__.py
+++ b/mat73/__init__.py
@@ -161,7 +161,7 @@ class HDF5Decoder():
             if  self.is_included(hdf5):
                 return self.convert_mat(hdf5, depth, MATLAB_class=MATLAB_class)
         else:
-            raise Exception(f'Unknown hdf5 type: {key}:{type(hdf5)}')
+            raise Exception(f'Unknown hdf5 type: {type(hdf5)}')
     
     # @profile
     def _has_refs(self, dataset):

--- a/tests/test_mat73.py
+++ b/tests/test_mat73.py
@@ -254,6 +254,17 @@ class Testing(unittest.TestCase):
         np.testing.assert_array_almost_equal(raw1['HSmooth'][0][2], [ 0.001139-4.233492e-04j,  0.00068 +8.927040e-06j,
         0.002382-7.647651e-04j, -0.012677+3.767829e-03j])
 
+    def test_file2_with_other_suffix(self):
+        """
+        Test that complex numbers are loaded correctly
+        """
+        new_file2 = self.testfile2.replace(".mat", ".other_suffix")
+        os.link(self.testfile2, new_file2)
+        assert (
+            str(mat73.loadmat(self.testfile2)) == 
+            str(mat73.loadmat(new_file2, strict_suffix=False))
+        )
+        os.remove(new_file2)
 
     def test_file3(self):
         """


### PR DESCRIPTION
I have some matlab files with the suffix not .mat lol